### PR TITLE
ENH add fetcher for the criteo dataset

### DIFF
--- a/libsvmdata/datasets.py
+++ b/libsvmdata/datasets.py
@@ -391,9 +391,6 @@ def _get_X_y(dataset, multilabel, replace=False, verbose=False):
                     f, n_features=n_features_total, multilabel=multilabel
                 )
 
-            if d == dataset:
-                X_y_ = X, y
-
             # recompute pathes adapt to each dataset in case it is an archive.
             y_path = f"{path}_target{ext}"
             X_path = f"{path}_data"
@@ -412,11 +409,14 @@ def _get_X_y(dataset, multilabel, replace=False, verbose=False):
                 indices = np.array([lab for labels in y for lab in labels])
                 indptr = np.cumsum([0] + [len(labels) for labels in y])
                 data = np.ones_like(indices)
-                Y = sparse.csr_matrix((data, indices, indptr))
-                sparse.save_npz(y_path, Y)
-
+                y = sparse.csr_matrix((data, indices, indptr))
+                sparse.save_npz(y_path, y)
             else:
                 np.save(y_path, y)
+
+            if d == dataset:
+                X_y_ = X, y
+
         X, y = X_y_
 
     else:

--- a/libsvmdata/datasets.py
+++ b/libsvmdata/datasets.py
@@ -344,9 +344,9 @@ def _get_X_y(dataset, multilabel, replace=False, verbose=False):
         tmp_path = DATA_HOME / stripped_name
         path_mapping = {str(tmp_path): dataset}
 
-    y_path = f"{tmp_path}_target{ext}"
+    y_path = tmp_path.parent / f"{tmp_path.name}_target{ext}"
     # no ext for X to handle npy or npz
-    X_path = f"{tmp_path}_data"
+    X_path = tmp_path.parent / f"{tmp_path.name}_data"
 
     if (replace or not y_path.exists()
         or not ((X_path.parent / (X_path.name + '.npy')).exists() or


### PR DESCRIPTION
This requires a bit more code as the dataset is shipped as a `tar` file containing both the train and test set.
This PR makes it possible to download/unzip and preprocess both train and test, to avoid wasting time downloading/uncompressing it twice.