### PR TITLE
ENH print available datasets on one line in error for unknown datasets

### DIFF
--- a/libsvmdata/datasets.py
+++ b/libsvmdata/datasets.py
@@ -431,7 +431,7 @@ def fetch_libsvm(dataset, replace=False, normalize=False, min_nnz=0,
     """
     if dataset not in NAMES:
         raise ValueError("Unsupported dataset %s. " % dataset +
-                         "Supported datasets are: \n- " + '\n- '.join(NAMES))
+                         "Supported datasets are: \n" + ', '.join(NAMES))
     multilabel = NAMES[dataset].split('/')[0] == 'multilabel'
     is_regression = NAMES[dataset].split('/')[0] == 'regression'
 


### PR DESCRIPTION
On terminals where you cannot scroll up, printing everything on a new line was a pain